### PR TITLE
Update runtime to Gnome 43

### DIFF
--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -1,6 +1,6 @@
 app-id: com.github.gabutakut.gabutdm
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '43'
 sdk: org.gnome.Sdk
 command: com.github.gabutakut.gabutdm
 finish-args:


### PR DESCRIPTION
Warning by flatpak: `The GNOME 42 runtime is no longer supported as of March 21, 2023. Please ask your application developer to migrate to a supported platform.`