### PR TITLE
Update gabutdm runtime to 46

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -1,6 +1,6 @@
 app-id: com.github.gabutakut.gabutdm
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: com.github.gabutakut.gabutdm
 finish-args:

--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -45,3 +45,5 @@ modules:
         url: https://github.com/gabutakut/gabutdm.git
         tag: '2.1.6'
         commit: 2cb7d682565f27f2ceff9d3dcd2645602a6b0f8f
+      - type: patch
+        path: fix_appdata.patch

--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -24,12 +24,7 @@ cleanup:
   - /share/gtk-doc
   - /lib/pkgconfig
 modules:
-  - name: libcanberra
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz
-        sha256: c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72
+  - shared-modules/libcanberra/libcanberra.json
   - name: libqrencode4
     buildsystem: autotools
     sources:

--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -18,6 +18,11 @@ cleanup:
   - '*.a'
   - '*.la'
   - '/include'
+  - /share/doc
+  - /share/man
+  - /share/vala
+  - /share/gtk-doc
+  - /lib/pkgconfig
 modules:
   - name: libcanberra
     buildsystem: autotools

--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -28,9 +28,9 @@ modules:
   - name: libqrencode4
     buildsystem: autotools
     sources:
-      - type: git
-        url: https://github.com/fukuchi/libqrencode.git
-        tag: v4.0.0
+      - type: archive
+        url: https://github.com/fukuchi/libqrencode/archive/refs/tags/v4.1.1.tar.gz
+        sha256: 5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c
   - name: aria2
     config-opts:
       - '--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt'

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,4 +1,4 @@
-From 475fd9ceb038765f4aca5cef0b67154ccf640607 Mon Sep 17 00:00:00 2001
+From c9d9ae3efdd40ad69cf0929bb1aa222b79ae321b Mon Sep 17 00:00:00 2001
 From: Sabri Ünal <yakushabb@gmail.com>
 Date: Thu, 13 Jun 2024 02:23:39 +0300
 Subject: [PATCH] appdata: Update appdata
@@ -9,7 +9,7 @@ Subject: [PATCH] appdata: Update appdata
  1 file changed, 6 insertions(+), 32 deletions(-)
 
 diff --git a/data/com.github.gabutakut.gabutdm.appdata.xml.in b/data/com.github.gabutakut.gabutdm.appdata.xml.in
-index d1be86a..5ed21ca 100644
+index d1be86a..eed432e 100644
 --- a/data/com.github.gabutakut.gabutdm.appdata.xml.in
 +++ b/data/com.github.gabutakut.gabutdm.appdata.xml.in
 @@ -166,42 +166,16 @@
@@ -53,7 +53,7 @@ index d1be86a..5ed21ca 100644
 +  <url type="bugtracker">https://github.com/gabutakut/gabutdm/issues</url>
 +  <url type="vcs-browser">https://github.com/gabutakut</url>
 +  <url type="help">https://github.com/gabutakut/gabutdm/issues</url>
-+  <launchable type="desktop-id">com.github.gabutakut.gabutdm</launchable>
++  <launchable type="desktop-id">com.github.gabutakut.gabutdm.desktop</launchable>
    <custom>
      <value key="x-appcenter-color-primary">#2A7D00</value>
      <value key="x-appcenter-color-primary-text">#d1ff82</value>

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,67 @@
+From 475fd9ceb038765f4aca5cef0b67154ccf640607 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Thu, 13 Jun 2024 02:23:39 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/com.github.gabutakut.gabutdm.appdata.xml.in | 38 ++++++--------------------------------
+ 1 file changed, 6 insertions(+), 32 deletions(-)
+
+diff --git a/data/com.github.gabutakut.gabutdm.appdata.xml.in b/data/com.github.gabutakut.gabutdm.appdata.xml.in
+index d1be86a..5ed21ca 100644
+--- a/data/com.github.gabutakut.gabutdm.appdata.xml.in
++++ b/data/com.github.gabutakut.gabutdm.appdata.xml.in
+@@ -166,42 +166,16 @@
+       <image>https://raw.githubusercontent.com/gabutakut/gabutdm/master/Screenshot3.png</image>
+     </screenshot>
+   </screenshots>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1" />
+   <developer_name>Gabut Akut</developer_name>
+   <url type="homepage">https://github.com/gabutakut</url>
+-  <url type="bugtracker">http://github.com/gabutakut/gabutdm/issues</url>
+-  <url type="help">http://github.com/gabutakut/gabutdm/issues</url>
++  <url type="bugtracker">https://github.com/gabutakut/gabutdm/issues</url>
++  <url type="vcs-browser">https://github.com/gabutakut</url>
++  <url type="help">https://github.com/gabutakut/gabutdm/issues</url>
++  <launchable type="desktop-id">com.github.gabutakut.gabutdm</launchable>
+   <custom>
+     <value key="x-appcenter-color-primary">#2A7D00</value>
+     <value key="x-appcenter-color-primary-text">#d1ff82</value>
+     <value key="x-appcenter-suggested-price">6</value>
+   </custom>
+-</component>
+\ No newline at end of file
++</component>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update gabutdm runtime to 46 since runtime version 44 has reached end-of-life.
- Use libcanberra from flathub shared modules.
- Update libqrencode version to 4.1.1.
- Remove redundant files to reduce package size.