### PR TITLE
Update runtime to 48

### DIFF
--- a/com.github.gabutakut.gabutdm.yml
+++ b/com.github.gabutakut.gabutdm.yml
@@ -1,6 +1,6 @@
 app-id: com.github.gabutakut.gabutdm
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: com.github.gabutakut.gabutdm
 finish-args:


### PR DESCRIPTION
just it

Fix warning: The GNOME 46 runtime is no longer supported as of April 17, 2025.